### PR TITLE
Add retrieval quality evaluation for RAG pipeline

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,11 +64,6 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@v2
 
-      - name: Run spellcheck
-        working-directory: site
-        run: bundle exec rake spellcheck
-        continue-on-error: true
-
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install sentence-transformers
+          pip install sentence-transformers numpy
           sudo apt-get update -y && sudo apt-get -y install aspell aspell-en locales
           echo "en_US UTF-8" | sudo tee -a /etc/locale.gen
           sudo locale-gen en_US.UTF-8
@@ -83,6 +83,10 @@ jobs:
           fi
         env:
           JEKYLL_ENV: production
+
+      - name: Evaluate retrieval quality
+        working-directory: site
+        run: just eval
 
       - name: Check deployment condition
         id: check-deploy

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,9 +84,9 @@ jobs:
         env:
           JEKYLL_ENV: production
 
-      - name: Evaluate retrieval quality
+      - name: Test site
         working-directory: site
-        run: just eval
+        run: just test
 
       - name: Check deployment condition
         id: check-deploy

--- a/site/justfile
+++ b/site/justfile
@@ -13,8 +13,6 @@ build *ARGS:
 test:
     bundle exec rake checkhtml
     export LANG=en_US.UTF-8 && export LANGUAGE=en_US:en && export LC_ALL=en_US.UTF-8 && bundle exec rake spellcheck
-
-eval:
     python3 tests/eval_retrieval.py
 
 run:

--- a/site/justfile
+++ b/site/justfile
@@ -14,6 +14,9 @@ test:
     bundle exec rake checkhtml
     export LANG=en_US.UTF-8 && export LANGUAGE=en_US:en && export LC_ALL=en_US.UTF-8 && bundle exec rake spellcheck
 
+eval:
+    python3 tests/eval_retrieval.py
+
 run:
     bundle exec jekyll serve
 

--- a/site/tests/eval_retrieval.py
+++ b/site/tests/eval_retrieval.py
@@ -1,0 +1,161 @@
+"""
+Retrieval quality evaluation for the ask page RAG pipeline.
+
+For each golden question, this script:
+1. Computes the query embedding using the same models as the pipeline.
+2. Ranks all chunks by cosine similarity (dot product on normalized vectors).
+3. Checks if the top-k retrieved chunks contain the expected content.
+
+Two checks per question:
+- Keyword hit: at least one top-k chunk contains at least one expected keyword.
+- Title hit: at least one top-k chunk comes from the expected blog post title.
+
+Exit code is non-zero if overall score falls below the threshold.
+"""
+
+import json
+import sys
+import os
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+TOP_K = 3
+PASS_THRESHOLD = 0.75
+
+MODELS = {
+    "all-MiniLM-L6-v2": {
+        "model_name": "all-MiniLM-L6-v2",
+        "embeddings_file": "_site/static/model/embeddings-all-MiniLM-L6-v2.json",
+    },
+    "bge-small-en-v1.5": {
+        "model_name": "BAAI/bge-small-en-v1.5",
+        "embeddings_file": "_site/static/model/embeddings-bge-small-en-v1.5.json",
+    },
+}
+
+
+def load_embeddings(filepath):
+    with open(filepath, "r") as f:
+        docs = json.load(f)
+    chunks = [d["chunk"] for d in docs]
+    embeddings = np.array([d["embedding"] for d in docs])
+    return chunks, embeddings
+
+
+def retrieve_top_k(query_embedding, embeddings, chunks, k):
+    """Return top-k chunks by cosine similarity (dot product on L2-normalized vectors)."""
+    similarities = embeddings @ query_embedding
+    top_indices = np.argsort(similarities)[::-1][:k]
+    return [(chunks[i], float(similarities[i])) for i in top_indices]
+
+
+def check_keyword_hit(retrieved_chunks, expected_keywords):
+    """True if at least one chunk contains at least one expected keyword (case-insensitive)."""
+    for chunk, _ in retrieved_chunks:
+        chunk_lower = chunk.lower()
+        for keyword in expected_keywords:
+            if keyword.lower() in chunk_lower:
+                return True
+    return False
+
+
+def check_title_hit(retrieved_chunks, expected_title):
+    """True if at least one chunk contains text from the expected post title."""
+    title_lower = expected_title.lower()
+    for chunk, _ in retrieved_chunks:
+        if title_lower in chunk.lower():
+            return True
+    # Also check for the "Title: ..." prefix used in embeddings generation.
+    for chunk, _ in retrieved_chunks:
+        if f"title: {title_lower}" in chunk.lower():
+            return True
+    return False
+
+
+def evaluate_model(model_key, model_config, golden_questions):
+    print(f"\n{'='*60}")
+    print(f"Evaluating model: {model_key}")
+    print(f"{'='*60}")
+
+    embeddings_path = model_config["embeddings_file"]
+    if not os.path.exists(embeddings_path):
+        print(f"  ERROR: embeddings file not found: {embeddings_path}")
+        return None
+
+    chunks, embeddings = load_embeddings(embeddings_path)
+    # Normalize embeddings for dot-product similarity.
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    norms[norms == 0] = 1
+    embeddings = embeddings / norms
+
+    print(f"  Loaded {len(chunks)} chunks")
+
+    model = SentenceTransformer(model_config["model_name"])
+
+    keyword_hits = 0
+    title_hits = 0
+    total = len(golden_questions)
+
+    for q in golden_questions:
+        query = q["question"]
+        query_embedding = model.encode(query)
+        query_embedding = query_embedding / np.linalg.norm(query_embedding)
+
+        retrieved = retrieve_top_k(query_embedding, embeddings, chunks, TOP_K)
+
+        kw_hit = check_keyword_hit(retrieved, q["expected_keywords"])
+        tt_hit = check_title_hit(retrieved, q["expected_title"])
+
+        keyword_hits += int(kw_hit)
+        title_hits += int(tt_hit)
+
+        status = "PASS" if (kw_hit and tt_hit) else "FAIL"
+        print(f"  [{status}] {query}")
+        if not kw_hit:
+            print(f"         keyword miss (expected: {q['expected_keywords']})")
+        if not tt_hit:
+            print(f"         title miss (expected: {q['expected_title']})")
+        if status == "FAIL":
+            print(f"         top chunk: {retrieved[0][0][:100]}...")
+
+    keyword_score = keyword_hits / total
+    title_score = title_hits / total
+    combined_score = (keyword_score + title_score) / 2
+
+    print(f"\n  Results for {model_key}:")
+    print(f"    Keyword hit rate: {keyword_hits}/{total} ({keyword_score:.0%})")
+    print(f"    Title hit rate:   {title_hits}/{total} ({title_score:.0%})")
+    print(f"    Combined score:   {combined_score:.0%}")
+
+    return combined_score
+
+
+def main():
+    golden_path = os.path.join(os.path.dirname(__file__), "golden_retrieval.json")
+    with open(golden_path, "r") as f:
+        golden_questions = json.load(f)
+
+    print(f"Loaded {len(golden_questions)} golden questions")
+
+    all_passed = True
+    for model_key, model_config in MODELS.items():
+        score = evaluate_model(model_key, model_config, golden_questions)
+        if score is None:
+            print(f"\n  SKIP: {model_key} (embeddings not available)")
+            continue
+        if score < PASS_THRESHOLD:
+            print(f"\n  FAIL: {model_key} score {score:.0%} < threshold {PASS_THRESHOLD:.0%}")
+            all_passed = False
+        else:
+            print(f"\n  PASS: {model_key} score {score:.0%} >= threshold {PASS_THRESHOLD:.0%}")
+
+    print(f"\n{'='*60}")
+    if all_passed:
+        print("Overall: PASS")
+    else:
+        print("Overall: FAIL")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/tests/golden_retrieval.json
+++ b/site/tests/golden_retrieval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "question": "What is an embedding in the context of AI?",
+    "expected_keywords": ["embedding", "numerical", "recipe", "word", "numbers"],
+    "expected_title": "Building Wonders Without Blueprints - How AI Learned to \"Understand\" Language",
+    "description": "The embeddings blog post explains what embeddings are using the recipe analogy"
+  },
+  {
+    "question": "How does Word2Vec work?",
+    "expected_keywords": ["Word2Vec", "nudge", "similar", "random", "billions"],
+    "expected_title": "Building Wonders Without Blueprints - How AI Learned to \"Understand\" Language",
+    "description": "The embeddings post has a section on Word2Vec"
+  },
+  {
+    "question": "What is king minus man plus woman?",
+    "expected_keywords": ["king", "queen", "woman", "man"],
+    "expected_title": "Building Wonders Without Blueprints - How AI Learned to \"Understand\" Language",
+    "description": "The famous word math example from the embeddings post"
+  },
+  {
+    "question": "What is a standard operating procedure?",
+    "expected_keywords": ["SOP", "runbook", "mitigate", "procedure"],
+    "expected_title": "What Makes a Good Standard Operating Procedure",
+    "description": "The SOP post defines what SOPs are and their purpose"
+  },
+  {
+    "question": "What are the sections in an SOP template?",
+    "expected_keywords": ["preamble", "steps", "testing", "check", "act", "verify"],
+    "expected_title": "What Makes a Good Standard Operating Procedure",
+    "description": "The SOP post describes the template sections"
+  },
+  {
+    "question": "How was the cloning myself project built?",
+    "expected_keywords": ["GitHub Pages", "browser", "embeddings", "clone"],
+    "expected_title": "Cloning Myself (Part 1)",
+    "description": "The cloning myself series describes building an AI clone"
+  },
+  {
+    "question": "What constraint did the cloning myself project have?",
+    "expected_keywords": ["GitHub Pages", "free", "browser", "no server"],
+    "expected_title": "Cloning Myself (Part 1)",
+    "description": "The key constraint was running on GitHub Pages with no backend"
+  },
+  {
+    "question": "What tools were used to generate embeddings for the blog?",
+    "expected_keywords": ["Gemini", "Python", "sentence", "embedding"],
+    "expected_title": "Cloning Myself - Basic Embeddings (Part 2)",
+    "description": "Part 2 describes using Gemini and a Python script to generate embeddings"
+  },
+  {
+    "question": "What are the components of IronPLC?",
+    "expected_keywords": ["Visual Studio Code", "Compiler", "Rust", "TypeScript"],
+    "expected_title": "Continuous Deployment for a Visual Studio Code Extension with Language Server Protocol",
+    "description": "The IronPLC pipeline post lists the components"
+  },
+  {
+    "question": "Why does ChatGPT seem to hate my boyfriend?",
+    "expected_keywords": ["agreeable", "word predictor", "chat history", "emotion"],
+    "expected_title": "Does AI love my boyfriend?",
+    "description": "The post explains why AI appears to have opinions about relationships"
+  },
+  {
+    "question": "What is ELIZA?",
+    "expected_keywords": ["ELIZA", "psychotherapist", "Rogerian", "computer program"],
+    "expected_title": "Does AI love my boyfriend?",
+    "description": "ELIZA is discussed as an example of anthropomorphizing computers"
+  },
+  {
+    "question": "What was the schematic capture feature for FPGAs?",
+    "expected_keywords": ["schematic", "VHDL", "FPGA", "high school"],
+    "expected_title": "Success at Work",
+    "description": "The early post about building a schematic capture feature"
+  }
+]


### PR DESCRIPTION
## Summary
This PR adds automated evaluation of the RAG (Retrieval-Augmented Generation) pipeline used by the ask page. It introduces a test suite that validates retrieval quality by checking if the top-k retrieved chunks contain expected content for golden questions.

## Key Changes
- **New evaluation script** (`site/tests/eval_retrieval.py`): Evaluates retrieval quality by:
  - Computing query embeddings using the same models as the production pipeline
  - Ranking chunks by cosine similarity on normalized vectors
  - Checking if top-3 retrieved chunks contain expected keywords and blog post titles
  - Reporting keyword hit rate, title hit rate, and combined score per model
  - Failing the test if combined score falls below 75% threshold

- **Golden test dataset** (`site/tests/golden_retrieval.json`): 12 curated questions covering the blog's main topics (embeddings, SOPs, AI cloning, IronPLC, etc.) with expected keywords and source titles for validation

- **CI/CD integration**: 
  - Updated `site/justfile` to run `eval_retrieval.py` as part of the test suite
  - Updated `.github/workflows/deploy.yaml` to add `numpy` dependency and execute tests before deployment
  - Removed spellcheck from the workflow (now part of the `just test` command)

## Implementation Details
- Uses `sentence-transformers` library to encode queries with the same models used in production (all-MiniLM-L6-v2 and bge-small-en-v1.5)
- Normalizes embeddings for dot-product similarity computation
- Performs case-insensitive keyword matching and title matching (including "Title: " prefix format)
- Provides detailed per-question diagnostics showing which checks failed and top retrieved chunk preview
- Gracefully skips models if embeddings files are unavailable

https://claude.ai/code/session_01DEJ2kSmdwosCLsrMa5mtVK