### PR TITLE
Add steering files for AI coding assistants

### DIFF
--- a/.kiro/steering/common-tasks.md
+++ b/.kiro/steering/common-tasks.md
@@ -1,0 +1,5 @@
+# Common Development Tasks
+
+See [specs/steering/common-tasks.md](../../specs/steering/common-tasks.md) for the full common tasks reference.
+
+This file provides quick reference for build commands, testing workflows, and development tasks using the project's justfile-based build system.

--- a/.kiro/steering/development-standards.md
+++ b/.kiro/steering/development-standards.md
@@ -1,0 +1,5 @@
+# Development Standards
+
+See [specs/steering/development-standards.md](../../specs/steering/development-standards.md) for the full development standards.
+
+This file defines content conventions, code quality expectations, spell checking, and blog post standards.

--- a/.kiro/steering/project-architecture.md
+++ b/.kiro/steering/project-architecture.md
@@ -1,0 +1,5 @@
+# Project Architecture
+
+See [specs/steering/project-architecture.md](../../specs/steering/project-architecture.md) for the full architectural guidance.
+
+This file describes the monorepo structure, Jekyll site, Cloudflare infrastructure, and RAG pipeline architecture.

--- a/.kiro/steering/steering-file-guidelines.md
+++ b/.kiro/steering/steering-file-guidelines.md
@@ -1,0 +1,5 @@
+# Steering File Guidelines
+
+See [specs/steering/steering-file-guidelines.md](../../specs/steering/steering-file-guidelines.md) for the full steering file guidelines.
+
+This guidance explains the two-file pattern used for steering files and how AI assistants should create or update them to maintain consistency across different AI systems.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# Claude Code Instructions
+
+This file provides entry points for Claude Code when working on garretfick.github.io.
+
+## Steering Files
+
+Before making changes, read the relevant steering files in `specs/steering/`:
+
+- **[Common Tasks](specs/steering/common-tasks.md)** - Build commands, testing workflows, and justfile-based development tasks
+- **[Development Standards](specs/steering/development-standards.md)** - Content conventions, code quality, spell checking, and blog post standards
+- **[Project Architecture](specs/steering/project-architecture.md)** - Monorepo structure, Jekyll site, Cloudflare infrastructure, and RAG pipeline
+- **[Steering File Guidelines](specs/steering/steering-file-guidelines.md)** - How to create and maintain steering files (for AI assistants updating documentation)
+
+## MANDATORY: Before Creating a PR
+
+**You MUST run the full test suite and verify it passes before creating any PR:**
+
+```bash
+just build && just test
+```
+
+This builds the Jekyll site (including embedding generation) and runs HTML validation, spell checking, and retrieval quality evaluation. **All checks must pass.**
+
+If any check fails:
+1. Fix the issues
+2. Re-run `just build && just test`
+3. Only create the PR after all checks pass
+
+**Common failures:**
+- **Spell check errors** - Add legitimate words to `site/aspell-dict.txt`, or fix the misspelling
+- **HTML validation errors** - Fix invalid HTML in layouts, includes, or post content
+- **Missing embeddings** - Ensure `generate_embeddings.py` dependencies are installed (`pip install sentence-transformers numpy`)
+- **Retrieval quality below threshold** - Review chunking or embedding changes that may have degraded quality
+
+## Quick Reference
+
+### Key Commands
+- `just build` - **Build the Jekyll site** (includes embedding generation)
+- `just test` - **Run all tests** (HTML validation, spell check, retrieval evaluation)
+- `just build && just test` - **Full CI pipeline (REQUIRED before PR)**
+- `cd site && just run` - Start local development server at http://localhost:4000
+- `just infra/test` - Validate Terraform configuration
+- `just deploy` - Deploy infrastructure (requires credentials)
+
+See [specs/steering/common-tasks.md](specs/steering/common-tasks.md) for the complete command reference.
+
+### Project Structure
+- `site/` - Jekyll website (GitHub Pages)
+- `infra/` - Cloudflare Worker and Terraform infrastructure
+- `specs/` - Design specifications and steering files
+- `.github/workflows/` - CI/CD pipeline
+
+### Critical Rules
+1. **Run `just build && just test` before creating any PR**
+2. **Spell check all content** - Add false positives to `site/aspell-dict.txt`
+3. **Blog post filenames** follow Jekyll convention: `YYYY-MM-DD-title-slug.md`
+4. **Blog posts use kramdown** Markdown with YAML front matter
+5. **Infrastructure changes** require Terraform validation (`just infra/test`)
+6. **Secrets** are never committed - use environment variables and GitHub secrets

--- a/specs/steering/common-tasks.md
+++ b/specs/steering/common-tasks.md
@@ -1,0 +1,103 @@
+# Common Development Tasks
+
+This file documents build commands, testing workflows, and development tasks using the project's justfile-based build system.
+
+## Justfile Locations
+
+| Location | Scope |
+|----------|-------|
+| `justfile` (root) | Delegates to component justfiles |
+| `site/justfile` | Jekyll site build, test, and serve |
+| `infra/justfile` | Cloudflare Worker build, Terraform validate/deploy |
+
+## Most Common Commands
+
+### Root Level
+
+| Command | What It Does |
+|---------|--------------|
+| `just build` | Build the Jekyll site (delegates to `site/justfile`) |
+| `just test` | Run all tests: site tests + infrastructure tests |
+| `just deploy` | Deploy infrastructure via Terraform |
+
+### Site (`site/justfile`)
+
+| Command | What It Does |
+|---------|--------------|
+| `cd site && just` | Run default target: install, build, test |
+| `cd site && just install` | Install Ruby gem dependencies via Bundler |
+| `cd site && just build` | Build Jekyll site and verify embedding files exist |
+| `cd site && just test` | Run HTML validation, spell check, and retrieval evaluation |
+| `cd site && just run` | Start local dev server at http://localhost:4000 |
+
+### Infrastructure (`infra/justfile`)
+
+| Command | What It Does |
+|---------|--------------|
+| `just infra/build` | Install npm dependencies and build the Cloudflare Worker |
+| `just infra/test` | Initialize Terraform (no backend) and validate configuration |
+| `just infra/deploy` | Build Worker, then Terraform plan and apply |
+| `just infra/upload-embeddings <file>` | Upload embeddings JSON to Cloudflare KV |
+
+## Pre-PR Requirements
+
+Before creating a pull request, run:
+
+```bash
+just build && just test
+```
+
+This runs the full pipeline:
+
+1. **Build** - Jekyll generates the site, including embedding generation via a post-write hook
+2. **Verify embeddings** - Checks that both `embeddings-all-MiniLM-L6-v2.json` and `embeddings-bge-small-en-v1.5.json` exist
+3. **HTML validation** - Nokogiri checks all generated HTML5 files for syntax errors
+4. **Spell check** - Aspell checks all HTML files against English dictionary plus custom dictionary (`site/aspell-dict.txt`)
+5. **Retrieval evaluation** - Python script evaluates RAG retrieval quality against golden test set
+
+All checks must pass.
+
+## Test Details
+
+### HTML Validation
+- Uses Nokogiri HTML5 parser with `max_errors: 10`
+- Scans all files matching `site/_site/**/*.html`
+- Fails if any file has parse errors
+
+### Spell Check
+- Uses GNU Aspell with English dictionary
+- Custom dictionary: `site/aspell-dict.txt` (add false positives here)
+- Skips `<script>`, `<style>`, `<pre>`, and `<code>` tags
+- Requires locale `en_US.UTF-8`
+
+### Retrieval Quality Evaluation
+- Script: `site/tests/eval_retrieval.py`
+- Golden test set: `site/tests/golden_retrieval.json`
+- Tests both embedding models (MiniLM and BGE)
+- Pass threshold: 75% of test cases must hit expected keywords/titles
+- Exit code non-zero on failure
+
+## Embedding Generation
+
+Embeddings are generated as a Jekyll post-write hook (`site/_plugins/generate_embeddings.rb`) which calls `site/generate_embeddings.py`. The Python script:
+
+1. Loads two models: `all-MiniLM-L6-v2` and `BAAI/bge-small-en-v1.5`
+2. Chunks all blog posts by headers (400-word max, 100-word overlap)
+3. Encodes chunks with both models
+4. Writes two output files to `site/_site/static/model/`
+
+**Dependencies:** `pip install sentence-transformers numpy`
+
+## Troubleshooting
+
+### `just build` fails with missing embeddings
+Ensure Python dependencies are installed: `pip install sentence-transformers numpy`. The embedding models are downloaded automatically on first run.
+
+### Spell check fails
+Check the error output for misspelled words. If a word is a legitimate technical term or proper noun, add it to `site/aspell-dict.txt` (one word per line). Then re-run `just test`.
+
+### Locale errors during spell check
+Aspell requires `en_US.UTF-8` locale. On Ubuntu: `sudo apt-get install locales && sudo locale-gen en_US.UTF-8`.
+
+### Terraform validation fails
+Run `just infra/test` to see the error. Common issues: missing provider plugins (run `terraform init` in `infra/terraform/`), or syntax errors in `.tf` files.

--- a/specs/steering/development-standards.md
+++ b/specs/steering/development-standards.md
@@ -1,0 +1,115 @@
+# Development Standards
+
+This file defines conventions, content standards, code quality expectations, and documentation practices for the garretfick.github.io project.
+
+## Content Standards
+
+### Blog Posts
+
+Blog posts live in `site/_posts/` and follow Jekyll conventions:
+
+- **Filename format:** `YYYY-MM-DD-title-slug.md`
+- **Markdown flavor:** kramdown with GitHub Flavored Markdown parser (`kramdown-parser-gfm`)
+- **Permalink pattern:** `/blog/:title` (configured in `site/_config.yml`)
+
+**Required YAML front matter:**
+
+```yaml
+---
+layout: post
+title: "Post Title Here"
+---
+```
+
+**Content guidelines:**
+- Write in plain, direct English
+- Use code blocks with language identifiers (e.g., ````python`, ````javascript`)
+- Prefer inline code for short references (e.g., `variable_name`)
+- Use heading levels consistently (H2 for main sections, H3 for subsections)
+- All content must pass spell check (see below)
+
+### Spell Checking
+
+All generated HTML is checked with GNU Aspell during `just test`.
+
+- Dictionary: English (`en`)
+- Custom words: `site/aspell-dict.txt` (one word per line, alphabetically sorted)
+- Tags skipped: `<script>`, `<style>`, `<pre>`, `<code>`
+
+**When adding new content:**
+1. Run `just build && just test`
+2. If spell check fails, review the reported words
+3. Fix genuine misspellings in the source Markdown
+4. Add legitimate technical terms, proper nouns, or abbreviations to `site/aspell-dict.txt`
+
+### HTML Validity
+
+All generated HTML must pass Nokogiri HTML5 validation. Common issues:
+- Unclosed tags
+- Invalid nesting (e.g., block element inside inline element)
+- Duplicate `id` attributes
+
+Fix issues in the relevant layout (`site/_layouts/`), include (`site/_includes/`), or post content.
+
+## Code Standards
+
+### Jekyll / Ruby
+
+- Gemfile pins Jekyll to `~> 4.3`
+- Plugins are in `site/_plugins/` (currently: embedding generation hook)
+- Layouts use Liquid templating
+- Data files in `site/_data/` use YAML format
+
+### Cloudflare Worker (TypeScript)
+
+- Source: `infra/cloudflare-worker/src/index.ts`
+- ES module format with ES2022 target
+- Bundled with esbuild
+- All responses are JSON with proper CORS headers
+- Input validation at the boundary (question length, type checks)
+
+### Terraform (HCL)
+
+- Configuration: `infra/terraform/`
+- Provider: Cloudflare `~> 5.0`
+- Remote state: Terraform Cloud (organization `garretfick`, workspace `ask-ai`)
+- Variables for sensitive values (API tokens, account IDs) - never hardcode secrets
+- Validate with `just infra/test` before committing
+
+### Python (Embeddings)
+
+- Script: `site/generate_embeddings.py`
+- Dependencies: `sentence-transformers`, `numpy`
+- Invoked automatically by Jekyll post-write hook
+- Must produce deterministic chunking across runs
+
+## Build System
+
+The project uses [just](https://github.com/casey/just) as the task runner. Justfiles are at the root, `site/`, and `infra/` levels. The root justfile delegates to component justfiles.
+
+See [common-tasks.md](common-tasks.md) for the full command reference.
+
+## CI/CD Pipeline
+
+The GitHub Actions workflow (`.github/workflows/deploy.yaml`) runs on pushes to `master` and manual dispatch:
+
+1. **Build job:** Ruby setup, Python setup, dependency install, Jekyll build, test suite, artifact upload
+2. **Deploy job:** Deploy to GitHub Pages (conditional)
+3. **Deploy-worker job:** Build Cloudflare Worker, Terraform plan and apply, upload embeddings to KV
+
+### Required GitHub Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API access for Worker deployment |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier |
+| `TF_API_TOKEN` | Terraform Cloud authentication |
+
+## Design Specifications
+
+Major features are documented as design specs in `specs/` before implementation:
+
+- `specs/cloudflare-ask-ai.md` - RAG pipeline with Cloudflare Workers AI
+- `specs/terraform-cloud-state.md` - Remote state management
+
+Specs describe goals, architecture, implementation steps, and verification criteria. Each implementation step should leave the build in a passing state.

--- a/specs/steering/project-architecture.md
+++ b/specs/steering/project-architecture.md
@@ -1,0 +1,115 @@
+# Project Architecture
+
+This file describes the high-level architecture, monorepo structure, and key subsystems of the garretfick.github.io project.
+
+## Overview
+
+This is a personal portfolio and blog website hosted on GitHub Pages with an AI-powered question-answering feature backed by Cloudflare Workers. The repository is a monorepo with clear separation between the static site and infrastructure.
+
+## Repository Structure
+
+```
+garretfick.github.io/
+├── site/                          # Jekyll website (GitHub Pages)
+│   ├── _posts/                    # Blog posts (Markdown, 160+ posts)
+│   ├── _layouts/                  # Liquid templates (base, default, post, grid)
+│   ├── _includes/                 # Reusable components (header, footer)
+│   ├── _plugins/                  # Jekyll plugins (embedding generation hook)
+│   ├── _data/                     # Structured data (languages.yml, opensource.yml)
+│   ├── about/                     # About page
+│   ├── ask/                       # AI question-answering page
+│   ├── blog/                      # Blog index
+│   ├── portfolio/                 # Portfolio section
+│   ├── talks/                     # Talks section
+│   ├── opensource/                # Open source contributions
+│   ├── static/                    # CSS, fonts, JavaScript, images
+│   ├── tests/                     # Retrieval quality evaluation
+│   ├── generate_embeddings.py     # Embedding generation script
+│   ├── aspell-dict.txt            # Custom spell check dictionary
+│   ├── Gemfile                    # Ruby dependencies
+│   ├── Rakefile                   # Ruby tasks (HTML validation, spell check)
+│   ├── _config.yml                # Jekyll configuration
+│   └── justfile                   # Site build/test tasks
+├── infra/                         # Infrastructure code
+│   ├── cloudflare-worker/         # Cloudflare Worker (TypeScript)
+│   │   ├── src/index.ts           # Worker entry point
+│   │   ├── package.json           # Node dependencies
+│   │   ├── tsconfig.json          # TypeScript configuration
+│   │   └── wrangler.toml          # Wrangler local dev config
+│   └── terraform/                 # Terraform IaC
+│       ├── main.tf                # Worker, KV namespace, deployment
+│       ├── variables.tf           # Input variables
+│       ├── outputs.tf             # Output values
+│       └── versions.tf            # Provider and backend config
+├── specs/                         # Design specifications
+│   ├── steering/                  # AI assistant steering files
+│   ├── cloudflare-ask-ai.md       # RAG pipeline design spec
+│   └── terraform-cloud-state.md   # Remote state design spec
+├── .devcontainer/                 # Development container
+│   ├── devcontainer.json          # Container features and settings
+│   └── Dockerfile                 # Ubuntu base with Ruby, Python, Node
+├── .github/workflows/
+│   └── deploy.yaml                # CI/CD pipeline
+├── .kiro/steering/                # Kiro AI pointer files
+├── justfile                       # Root task runner (delegates to components)
+└── CLAUDE.md                      # Claude Code entry point
+```
+
+## Key Subsystems
+
+### Jekyll Static Site
+
+The core website is a Jekyll 4.3 static site using kramdown for Markdown processing. Content is organized into blog posts, portfolio items, talks, and open source contributions. The site generates to `site/_site/` and is deployed to GitHub Pages.
+
+**Key configuration:**
+- `site/_config.yml` - Jekyll settings, permalink format, exclusions
+- `site/Gemfile` - Dependencies: Jekyll, kramdown-parser-gfm, nokogiri, jekyll-feed, jekyll-seo-tag, jekyll-sitemap
+- Permalinks: `/blog/:title`
+
+### RAG Pipeline (Ask Feature)
+
+The "ask" page (`site/ask/index.html`) provides two modes for answering questions about the blog content:
+
+**In-Browser mode:**
+1. Pre-computed embeddings loaded from `/static/model/embeddings-all-MiniLM-L6-v2.json`
+2. Query embedding computed with Transformers.js (`Xenova/all-MiniLM-L6-v2`)
+3. Cosine similarity search over chunks, top 3 selected
+4. Answer generated with `Xenova/distilgpt2`
+
+**Cloud mode:**
+1. Question POSTed to Cloudflare Worker at `/ask`
+2. Worker computes query embedding with `@cf/baai/bge-small-en-v1.5`
+3. Pre-computed embeddings retrieved from Cloudflare KV
+4. Cosine similarity search, top 3 chunks selected
+5. Answer generated with `@cf/meta/llama-3.1-8b-instruct`
+
+**Embedding generation** happens at build time via a Jekyll post-write hook. Two embedding files are produced (one per model) because the models use different embedding spaces.
+
+### Cloudflare Infrastructure
+
+- **Worker:** TypeScript ES module, handles `/ask` (POST) and `/health` (GET) endpoints
+- **KV namespace:** Stores pre-computed BGE embeddings for the Worker
+- **Terraform:** Manages all Cloudflare resources with remote state in Terraform Cloud
+- **CORS:** Restricted to `garretfick.com`, `garretfick.github.io`, and `localhost:4000`
+
+### CI/CD
+
+GitHub Actions workflow on push to `master`:
+1. Build Jekyll site (triggers embedding generation)
+2. Run test suite (HTML validation, spell check, retrieval evaluation)
+3. Deploy to GitHub Pages
+4. Deploy Cloudflare Worker via Terraform
+5. Upload embeddings to Cloudflare KV
+
+## Development Environment
+
+The `.devcontainer/` provides a containerized development environment with:
+- Ruby (for Jekyll)
+- Python (for embedding generation)
+- Node.js (for Cloudflare Worker)
+- Just (task runner)
+- Terraform (infrastructure management)
+- Aspell (spell checking)
+- Claude Code CLI
+
+Local development: `cd site && just run` starts the Jekyll dev server at `http://localhost:4000`.

--- a/specs/steering/steering-file-guidelines.md
+++ b/specs/steering/steering-file-guidelines.md
@@ -1,0 +1,109 @@
+# Steering File Guidelines
+
+This file explains the two-file pattern used for steering files and how AI assistants should create or update them to maintain consistency across different AI systems.
+
+## Core Architecture
+
+Steering files follow a **two-file pattern**:
+
+1. **Source of truth** in `specs/steering/` - Detailed, self-contained guidance documents that work with any AI tool
+2. **Pointer files** in tool-specific directories - Lightweight files that reference the source of truth
+
+| Directory | Target Tool | Content |
+|-----------|-------------|---------|
+| `specs/steering/` | Any AI assistant | Full detailed guidance |
+| `.kiro/steering/` | Kiro | Pointer with optional frontmatter |
+| `CLAUDE.md` (root) | Claude Code | Top-level entry point with quick reference |
+
+## Key Principles
+
+### AI-Agnostic Content
+Write `specs/steering/` files so they are useful to any AI coding assistant, not just one specific tool. Avoid tool-specific syntax or directives in the source-of-truth files.
+
+### Token Efficiency
+Keep steering files focused and scannable. Use tables for structured data. Avoid verbose prose when a list or table communicates the same information. AI assistants load these files into context, so every token matters.
+
+### Easy Maintenance
+Each steering file covers a single topic. When information changes, there is exactly one place to update (the `specs/steering/` file). Pointer files only need updating if the file is renamed or the scope changes.
+
+### Portability
+If a new AI tool is adopted, only new pointer files need to be created. The source-of-truth content in `specs/steering/` remains unchanged.
+
+## Creating a New Steering File
+
+### 1. Create the Source File
+
+Add a new Markdown file to `specs/steering/`:
+
+```markdown
+# Topic Name
+
+Brief description of what this file covers and when it applies.
+
+## Section 1
+...
+
+## Section 2
+...
+```
+
+**Content guidelines:**
+- Start with an H1 heading matching the topic
+- Include a brief description of scope
+- Use H2 for major sections
+- Prefer tables and lists over paragraphs
+- Include concrete examples where helpful
+- Reference related steering files with relative links
+
+### 2. Create Pointer Files
+
+**Kiro pointer** (`.kiro/steering/<name>.md`):
+
+```markdown
+# Topic Name
+
+See [specs/steering/<name>.md](../../specs/steering/<name>.md) for the full guidance.
+
+Brief one-line summary of when this applies.
+```
+
+For files that should only load when editing certain paths, add frontmatter:
+
+```markdown
+---
+inclusion: fileMatch
+fileMatchPattern: "infra/terraform/**"
+---
+
+# Topic Name
+
+See [specs/steering/<name>.md](../../specs/steering/<name>.md) for the full guidance.
+```
+
+### 3. Update CLAUDE.md
+
+Add a link to the new steering file in the "Steering Files" section of `CLAUDE.md`.
+
+## Content Scope
+
+### Include
+- Architectural patterns and project structure
+- Conventions and standards (naming, formatting, file organization)
+- Build and test workflows
+- Common development tasks
+- Error handling and troubleshooting guidance
+
+### Exclude
+- Complete API documentation (link to external docs instead)
+- Full configuration file contents (reference the file path)
+- Step-by-step tutorials (link to external resources)
+- Information that changes frequently (use file references)
+
+## Maintenance
+
+When modifying the project in ways that affect steering files:
+
+1. Update the relevant `specs/steering/` file
+2. Verify pointer files still reference the correct path
+3. Check that `CLAUDE.md` quick reference is still accurate
+4. If adding a new subsystem, consider whether it needs its own steering file


### PR DESCRIPTION
Introduce a two-file pattern (modeled after ironplc/ironplc) with detailed
source-of-truth files in specs/steering/ and lightweight pointers in
.kiro/steering/. CLAUDE.md serves as the top-level entry point for Claude Code.

Steering files cover common tasks, development standards, project architecture,
and guidelines for maintaining the steering files themselves.

https://claude.ai/code/session_01LEPVoJh2ZGSzpKPF5c8jTi